### PR TITLE
Trivial change to test whether this triggers the 'foo' job

### DIFF
--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -1,1 +1,1 @@
-Trivial file to test whether editing this adds the parameter to the `continue_config.yml`.
+A trivial file to test whether editing this adds the parameter to the `continue_config.yml`.


### PR DESCRIPTION
On running the `check-update-files` job in [Local CI](https://github.com/getlocalci/local-ci), it looks like it's correctly adding the 'build-api-gateway' job:

![Screen Shot 2022-08-23 at 10 12 29 PM](https://user-images.githubusercontent.com/4063887/186312478-ce993664-e08b-4171-a92d-1d17e6d35622.png)
 